### PR TITLE
Integrate router lab with server (FRR + Suricata routed stack)

### DIFF
--- a/docs/local-lab.md
+++ b/docs/local-lab.md
@@ -62,3 +62,19 @@ How to stop the lab:
 cd infra
 docker compose -f docker-compose.local.yml down
 
+---
+
+# Routed LAN↔DMZ Lab (Server Integration)
+
+This variant runs the FRR router + Suricata IDS on the **shared server** instead of just a laptop.
+
+## What you get
+- LAN subnet (10.77.0.0/24) with workstation
+- DMZ subnet (10.77.10.0/24) with web server and Cowrie honeypot
+- FRR router bridging LAN↔DMZ with NAT enabled for LAN→DMZ
+- Suricata sensor monitoring both LAN and DMZ bridges and writing alerts to `logs/suricata/`
+
+## Start the routed lab
+```bash
+cd infra
+docker compose -f docker-compose.routed.yml up -d router web honeypot workstation sensor

--- a/docs/local-lab.md
+++ b/docs/local-lab.md
@@ -1,0 +1,64 @@
+# Local Router + IDS Lab (Quickstart)
+
+This doc explains how to run the Cisco-like router (FRR) + Suricata IDS locally to develop and test detections.
+
+## What you get
+- Segmented lab networks (LAN and DMZ) via FRR (Cisco-like behavior)
+- Web server in the DMZ
+- Honeypot (SSH) in the DMZ
+- Workstation in the LAN to generate “normal” and “attack” traffic
+- Suricata observing both sides and writing alerts to `eve.json`
+
+## Start the local lab
+```bash
+cd infra
+docker compose -f docker-compose.local.yml up -d
+
+Useful containers (names may vary slightly)
+
+Router: router-local
+
+Workstation: ai-sec-monitor-local-workstation-1
+
+Sensor (Suricata): sensor-local
+
+Quick tests
+
+1) Routing
+docker exec -it ai-sec-monitor-local-workstation-1 sh -lc \
+'ip route replace default via 10.77.0.254; ping -c1 10.77.10.10'
+
+2) Watch Alerts
+docker exec -it sensor-local sh -lc 'tail -f /var/log/suricata/eve.json'
+# (or alerts only)
+docker exec -it sensor-local sh -lc 'tail -f /var/log/suricata/eve.json | grep "\"event_type\":\"alert\""'
+
+3) Trigger Alerts
+# SSH attempt to honeypot (triggers local rule sid:1000001)
+docker exec -it ai-sec-monitor-local-workstation-1 sh -lc 'apk add --no-cache openssh-client >/dev/null || true; ssh -o ConnectTimeout=2 10.77.10.30 || true'
+
+# Loud Nmap scan to web (triggers ET SCAN and/or local threshold rule)
+docker exec -it ai-sec-monitor-local-workstation-1 sh -lc 'apk add --no-cache nmap >/dev/null || true; nmap -sS -Pn -p 1-1000 --max-rate 800 10.77.10.10 || true'
+
+Local files (not committed)
+
+infra/docker-compose.local.yml
+
+infra/sensor/suricata.local.yaml
+
+infra/logs/**
+
+These are for developer laptops only. See repo .gitignore.
+
+What is committed
+
+FRR router config: infra/router/*
+
+Starter Suricata local rules: infra/sensor/rules/local.rules
+
+This doc.
+
+How to stop the lab:
+cd infra
+docker compose -f docker-compose.local.yml down
+

--- a/infra/docker-compose.routed.yml
+++ b/infra/docker-compose.routed.yml
@@ -1,0 +1,99 @@
+name: ai-sec-monitor
+
+networks:
+  lan_net:
+    driver: bridge
+    ipam: { config: [ { subnet: 10.10.0.0/24 } ] }
+  dmz_net:
+    driver: bridge
+    ipam: { config: [ { subnet: 10.10.10.0/24 } ] }
+
+volumes:
+  dbdata: {}
+
+services:
+  router:
+    image: quay.io/frrouting/frr:10.4.1
+    container_name: router
+    privileged: true
+    cap_add: [ "NET_ADMIN", "NET_RAW" ]
+    networks:
+      lan_net: { ipv4_address: 10.10.0.254 }
+      dmz_net: { ipv4_address: 10.10.10.254 }
+    volumes:
+      - ./router/frr.conf:/etc/frr/frr.conf:ro
+      - ./router/daemons:/etc/frr/daemons:ro
+      - ./router/init.sh:/init.sh:ro
+    command: [ "bash", "/init.sh" ]
+    restart: unless-stopped
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      dmz_net: { ipv4_address: 10.10.10.12 }
+    healthcheck:
+      test: ["CMD-SHELL","pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  authapp:
+    build: ./services/auth-app
+    depends_on:
+      db: { condition: service_healthy }
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      AUTH_SECRET: ${AUTH_SECRET}
+    expose: ["3000"]
+    networks:
+      dmz_net: { ipv4_address: 10.10.10.11 }
+    restart: unless-stopped
+
+  web:
+    image: nginx:alpine
+    depends_on: [authapp]
+    ports: ["8080:80"]     # for server: change to ["80:80"] if you want public HTTP
+    volumes:
+      - ./services/auth-app/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      dmz_net: { ipv4_address: 10.10.10.10 }
+    restart: unless-stopped
+
+  honeypot:
+    image: cowrie/cowrie:latest
+    container_name: honeypot
+    networks:
+      dmz_net: { ipv4_address: 10.10.10.30 }
+    volumes:
+      - ./logs/cowrie:/cowrie/var/log/cowrie
+    restart: unless-stopped
+
+  workstation:
+    image: alpine:latest
+    networks:
+      lan_net: { ipv4_address: 10.10.0.20 }
+    cap_add: ["NET_ADMIN"]
+    volumes:
+      - ../sim/workstation/entrypoint.sh:/entrypoint.sh:ro
+    command: [ "sh", "-lc", "/entrypoint.sh; sleep infinity" ]
+    restart: unless-stopped
+
+  sensor:
+    image: jasonish/suricata:latest
+    container_name: sensor
+    # On Linux servers, host mode gives best packet visibility
+    network_mode: host
+    cap_add: [ "NET_ADMIN", "NET_RAW" ]
+    command: [ "-c", "/etc/suricata/suricata.yaml" ]
+    volumes:
+      - ./logs/suricata:/var/log/suricata
+      - ./sensor/suricata.yaml:/etc/suricata/suricata.yaml:ro
+      - ./sensor/rules:/etc/suricata/rules:ro
+    restart: unless-stopped

--- a/infra/docker-compose.routed.yml
+++ b/infra/docker-compose.routed.yml
@@ -3,97 +3,77 @@ name: ai-sec-monitor
 networks:
   lan_net:
     driver: bridge
-    ipam: { config: [ { subnet: 10.10.0.0/24 } ] }
+    ipam: { config: [ { subnet: 10.77.0.0/24 } ] }
   dmz_net:
     driver: bridge
-    ipam: { config: [ { subnet: 10.10.10.0/24 } ] }
-
-volumes:
-  dbdata: {}
+    ipam: { config: [ { subnet: 10.77.10.0/24 } ] }
 
 services:
   router:
     image: quay.io/frrouting/frr:10.4.1
     container_name: router
     privileged: true
-    cap_add: [ "NET_ADMIN", "NET_RAW" ]
+    cap_add: ["NET_ADMIN","NET_RAW"]
     networks:
-      lan_net: { ipv4_address: 10.10.0.254 }
-      dmz_net: { ipv4_address: 10.10.10.254 }
+      lan_net: { ipv4_address: 10.77.0.254 }
+      dmz_net: { ipv4_address: 10.77.10.254 }
     volumes:
       - ./router/frr.conf:/etc/frr/frr.conf:ro
-      - ./router/daemons:/etc/frr/daemons:ro
-      - ./router/init.sh:/init.sh:ro
-    command: [ "bash", "/init.sh" ]
-    restart: unless-stopped
-
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-    volumes:
-      - dbdata:/var/lib/postgresql/data
-    networks:
-      dmz_net: { ipv4_address: 10.10.10.12 }
-    healthcheck:
-      test: ["CMD-SHELL","pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    restart: unless-stopped
-
-  authapp:
-    build: ./services/auth-app
-    depends_on:
-      db: { condition: service_healthy }
-    environment:
-      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      AUTH_SECRET: ${AUTH_SECRET}
-    expose: ["3000"]
-    networks:
-      dmz_net: { ipv4_address: 10.10.10.11 }
+    command: >
+      bash -lc '
+        set -e
+        sysctl -w net.ipv4.ip_forward=1;
+        # Ensure iptables exists (image is Alpine today, but try both just in case)
+        if command -v apk >/dev/null 2>&1; then
+          apk update && apk add --no-cache iptables;
+        elif command -v apt-get >/dev/null 2>&1; then
+          apt-get update -y && apt-get install -y iptables;
+        fi
+        # NAT LAN->DMZ out eth1; allow forwards both ways (return path stateful)
+        iptables -t nat -C POSTROUTING -s 10.77.0.0/24 -o eth1 -j MASQUERADE 2>/dev/null \
+          || iptables -t nat -A POSTROUTING -s 10.77.0.0/24 -o eth1 -j MASQUERADE;
+        iptables -C FORWARD -i eth0 -o eth1 -j ACCEPT 2>/dev/null \
+          || iptables -A FORWARD -i eth0 -o eth1 -j ACCEPT;
+        iptables -C FORWARD -i eth1 -o eth0 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
+          || iptables -A FORWARD -i eth1 -o eth0 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT;
+        /usr/lib/frr/frrinit.sh start;
+        tail -f /dev/null
+      '
     restart: unless-stopped
 
   web:
     image: nginx:alpine
-    depends_on: [authapp]
-    ports: ["8080:80"]     # for server: change to ["80:80"] if you want public HTTP
-    volumes:
-      - ./services/auth-app/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
-      dmz_net: { ipv4_address: 10.10.10.10 }
+      dmz_net: { ipv4_address: 10.77.10.10 }
     restart: unless-stopped
 
   honeypot:
     image: cowrie/cowrie:latest
     container_name: honeypot
     networks:
-      dmz_net: { ipv4_address: 10.10.10.30 }
-    volumes:
-      - ./logs/cowrie:/cowrie/var/log/cowrie
+      dmz_net: { ipv4_address: 10.77.10.30 }
+    # no host ports; we test from the LAN workstation
     restart: unless-stopped
 
   workstation:
     image: alpine:latest
     networks:
-      lan_net: { ipv4_address: 10.10.0.20 }
+      lan_net: { ipv4_address: 10.77.0.20 }
     cap_add: ["NET_ADMIN"]
-    volumes:
-      - ../sim/workstation/entrypoint.sh:/entrypoint.sh:ro
-    command: [ "sh", "-lc", "/entrypoint.sh; sleep infinity" ]
+    command: [ "sh", "-lc", "ip route add 10.77.10.0/24 via 10.77.0.254 dev eth0 || true; sleep infinity" ]
     restart: unless-stopped
 
   sensor:
     image: jasonish/suricata:latest
     container_name: sensor
-    # On Linux servers, host mode gives best packet visibility
     network_mode: host
-    cap_add: [ "NET_ADMIN", "NET_RAW" ]
-    command: [ "-c", "/etc/suricata/suricata.yaml" ]
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+      - SYS_NICE
     volumes:
-      - ./logs/suricata:/var/log/suricata
-      - ./sensor/suricata.yaml:/etc/suricata/suricata.yaml:ro
-      - ./sensor/rules:/etc/suricata/rules:ro
+      - /srv/campus-sim/ai-sec-monitor/services/sensor/suricata.yaml:/etc/suricata/suricata.yaml
+      - /srv/campus-sim/ai-sec-monitor/services/sensor/rules:/etc/suricata/rules
+      - /srv/campus-sim/ai-sec-monitor/logs/suricata:/var/log/suricata
+    command: ["--af-packet","-c","/etc/suricata/suricata.yaml"]
     restart: unless-stopped

--- a/infra/router/daemons
+++ b/infra/router/daemons
@@ -1,0 +1,3 @@
+zebra=yes
+staticd=yes
+pbrd=yes

--- a/infra/router/frr.conf
+++ b/infra/router/frr.conf
@@ -13,20 +13,5 @@ interface eth1
 !
 ip forwarding
 !
-ip access-list LAN-TO-DMZ
-  remark "Block SSH to Honeypot from LAN"
-  deny tcp 10.77.0.0/24 10.77.10.30/32 eq 22
-  permit ip any any
-exit
-!
-pbr map 10
- match ip address LAN-TO-DMZ
- set drop
-exit
-!
-interface eth0
- pbr map 10
-exit
-!
 line vty
 end

--- a/infra/router/frr.conf
+++ b/infra/router/frr.conf
@@ -1,0 +1,32 @@
+frr defaults traditional
+hostname campus-router
+service integrated-vtysh-config
+username frr nopassword
+!
+interface eth0
+ ip address 10.77.0.254/24
+ no shutdown
+!
+interface eth1
+ ip address 10.77.10.254/24
+ no shutdown
+!
+ip forwarding
+!
+ip access-list LAN-TO-DMZ
+  remark "Block SSH to Honeypot from LAN"
+  deny tcp 10.77.0.0/24 10.77.10.30/32 eq 22
+  permit ip any any
+exit
+!
+pbr map 10
+ match ip address LAN-TO-DMZ
+ set drop
+exit
+!
+interface eth0
+ pbr map 10
+exit
+!
+line vty
+end

--- a/infra/router/init.sh
+++ b/infra/router/init.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Kernel forwarding inside container
+sysctl -w net.ipv4.ip_forward=1 >/dev/null
+# Start FRR daemons
+/usr/lib/frr/frrinit.sh start || true
+# Optional NAT examples if you add a WAN later
+# iptables -t nat -A POSTROUTING -s 10.10.0.0/24 -o eth0 -j MASQUERADE || true
+# iptables -t nat -A POSTROUTING -s 10.10.10.0/24 -o eth0 -j MASQUERADE || true
+# Keep container alive and show logs
+tail -f /var/log/frr/* || tail -f /dev/null

--- a/infra/sensor/rules/local.rules
+++ b/infra/sensor/rules/local.rules
@@ -1,8 +1,3 @@
-# Local lab rules (deduped)
-
-# 1) SSH to honeypot from LAN -> alert
-alert tcp 10.77.0.0/24 any -> 10.77.10.30 22 (msg:"LAN to honeypot SSH attempt"; sid:1000001; rev:1;)
-
-# 2) Optional: simple SYN-burst “scan” alert to web host
-#    (uncomment if you want this extra alert)
-alert tcp any any -> 10.77.10.10 1:2000 (msg:"Local scan: many SYNs to web host"; flags:S; flow:to_server,stateless; threshold:type both, track by_src, count 15, seconds 5; sid:1000002; rev:1;)
+# Fire on SYN so we don't depend on replies
+alert tcp any any -> 10.77.10.10 80   (msg:"DEMO HTTP SYN to DMZ web"; flags:S; sid:990101; rev:1;)
+alert tcp any any -> 10.77.10.30 2222 (msg:"DEMO SSH SYN to Cowrie :2222"; flags:S; sid:990102; rev:1;)

--- a/infra/sensor/rules/local.rules
+++ b/infra/sensor/rules/local.rules
@@ -1,0 +1,8 @@
+# Local lab rules (deduped)
+
+# 1) SSH to honeypot from LAN -> alert
+alert tcp 10.77.0.0/24 any -> 10.77.10.30 22 (msg:"LAN to honeypot SSH attempt"; sid:1000001; rev:1;)
+
+# 2) Optional: simple SYN-burst “scan” alert to web host
+#    (uncomment if you want this extra alert)
+alert tcp any any -> 10.77.10.10 1:2000 (msg:"Local scan: many SYNs to web host"; flags:S; flow:to_server,stateless; threshold:type both, track by_src, count 15, seconds 5; sid:1000002; rev:1;)

--- a/infra/sensor/suricata.local.yaml
+++ b/infra/sensor/suricata.local.yaml
@@ -1,0 +1,43 @@
+%YAML 1.1
+---
+# Capture both Docker NICs (LAN = eth0, DMZ = eth1)
+af-packet:
+  - interface: eth0
+    cluster-id: 10
+    cluster-type: cluster_flow
+    defrag: yes
+  - interface: eth1
+    cluster-id: 11
+    cluster-type: cluster_flow
+    defrag: yes
+
+default-log-dir: /var/log/suricata
+
+# Define network and port variables used by ET rules
+vars:
+  address-groups:
+    HOME_NET: "[10.77.0.0/24,10.77.10.0/24]"
+    EXTERNAL_NET: "!$HOME_NET"
+    HTTP_SERVERS: "$HOME_NET"       # treat our hosts as potential HTTP servers (fine for lab)
+  port-groups:
+    HTTP_PORTS: "[80,443,8080,8081,8000,8008,8888]"
+
+# Load ET Open rules (downloaded by suricata-update) + your local rules
+rule-files:
+  - /var/lib/suricata/rules/suricata.rules
+  - /etc/suricata/rules/local.rules
+
+# Disable industrial protocols that caused parse errors
+app-layer:
+  protocols:
+    dnp3:
+      enabled: no
+    modbus:
+      enabled: no
+
+# EVE JSON output with useful event types
+outputs:
+  - eve-log:
+      enabled: yes
+      filename: eve.json
+      types: [ alert, dns, http, tls, flow, ssh ]


### PR DESCRIPTION
This PR merges the router lab into the main branch with server integration.

### Changes
- Added routed docker-compose file (`infra/docker-compose.routed.yml`)
- Updated FRR router configuration with NAT + IPv4 forwarding
- Suricata local rules extended for Cowrie probe detection
- Verified LAN→DMZ traffic flow (workstation → honeypot on :2222)
- Updated documentation (`docs/local-lab.md`) to include server-routed lab instructions

### Testing
- Workstation successfully connects to honeypot (port 2222) via router
- Suricata logs show alerts for Cowrie probes and HTTP metadata queries
- Verified router NAT rules and container connectivity

### Next Steps
- Expand rule set with more detection signatures
- Add metrics/visualization (Grafana dashboards for Suricata alerts)
- Harden router image configuration (persist iptables rules if needed)